### PR TITLE
Add DPI connection support

### DIFF
--- a/drmconnector.cpp
+++ b/drmconnector.cpp
@@ -96,7 +96,7 @@ bool DrmConnector::external() const {
   return type_ == DRM_MODE_CONNECTOR_HDMIA ||
          type_ == DRM_MODE_CONNECTOR_DisplayPort ||
          type_ == DRM_MODE_CONNECTOR_DVID || type_ == DRM_MODE_CONNECTOR_DVII ||
-         type_ == DRM_MODE_CONNECTOR_VGA;
+         type_ == DRM_MODE_CONNECTOR_VGA || type_ == DRM_MODE_CONNECTOR_DPI;
 }
 
 bool DrmConnector::writeback() const {


### PR DESCRIPTION
This commit adds support for DPI display in hwcomposer. Which in my case can run a vga display via a vga666 like resistor network.

Without this commit, hwcomposer doesn't draw in DPI display, so android doesn't start up.